### PR TITLE
bug regarding pawn captures

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -40,12 +40,12 @@ bool isMoveValid(Chess::Position present, Chess::Position future, Chess::EnPassa
         // Check if the opponent's last move was a two-square pawn move
         if (toupper(lastMovedPiece) == 'P' && abs(LastMoveTo.iRow - LastMoveFrom.iRow) == 2 &&
             abs(LastMoveFrom.iColumn - present.iColumn) == 1) {
-            cout << "En passant move detected and valid.\n";
             // Apply en passant capture
             S_enPassant->bApplied = true;
             S_enPassant->PawnCaptured.iRow = LastMoveTo.iRow;
             S_enPassant->PawnCaptured.iColumn = LastMoveTo.iColumn;
             bValid = true;
+            cout << "En passant move!\n";
             return bValid; // Exit after en passant
         }
     }
@@ -54,13 +54,11 @@ bool isMoveValid(Chess::Position present, Chess::Position future, Chess::EnPassa
     if (1 == abs(future.iColumn - present.iColumn)) {
         if ((Chess::isWhitePiece(chPiece) && future.iRow == present.iRow + 1) ||
             (Chess::isBlackPiece(chPiece) && future.iRow == present.iRow - 1)) {
-            char targetPiece = current_game->getPieceAtPosition(future.iRow, future.iColumn);
-            cout << "Target square content: " << targetPiece << " (expected opponent's piece).\n";
-
-            if (EMPTY_SQUARE != targetPiece) {
-                
-                bValid = true;
-            } else {
+            if (EMPTY_SQUARE != current_game->getPieceAtPosition(future.iRow, future.iColumn))
+               {
+                  bValid = true;
+                  cout << "Pawn captured a piece!\n";
+               } else {
                 return false;
             }
         } else {
@@ -97,7 +95,13 @@ bool isMoveValid(Chess::Position present, Chess::Position future, Chess::EnPassa
         else {
             return false;
         }
-    }    
+    }  // If a pawn reaches its eight rank, it must be promoted to another piece
+         if ( (Chess::isWhitePiece( chPiece ) && 7 == future.iRow) ||
+              (Chess::isBlackPiece( chPiece ) && 0 == future.iRow) )
+         {
+            cout << "Pawn must be promoted!\n";
+            S_promotion->bApplied = true;
+         }   
 }
 break;
       case 'R':


### PR DESCRIPTION
When a white pawn is in row 5 (or row 4 for black) and an opponent pawn on a adjacent column is still in is starting position (row 2 or 7 for white or black), if the opponent move one square forward (instead of the 2 required for en passant), the game will say that capturing it is an illegal move, even though it's perfectly legal, it has nothing different than any other pawn capture. The issue is that the "else if" condition is met (the pawn is on the required row), but further conditions are not met (opponent pawn moving 2 square), meaning that the program consider true the condition for the else if, therefore skipping the following else if, where normal diagonal pawn capture is implemented. To fix this I separated these parts, so that en passant and pawn capture aren't anymore connected in the same else if chain.